### PR TITLE
Use flexbox to improve spacing of the league table

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -256,12 +256,12 @@ span {
 #overlay-side-scores {
 	.row {
 		width: 180px;
-	}
-	.score {
-		padding-left: 30px;
-	}
-	.position {
-		padding-right: 30px;
+
+		.content p {
+			display: flex;
+			justify-content: space-between;
+			padding: 0 .25em;
+		}
 	}
 	.score::after {
 		content: "pts";


### PR DESCRIPTION
| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/cac451c5-a235-487d-979b-1b3212b72fcf) | ![image](https://github.com/user-attachments/assets/c7f9ca06-ef7c-4e34-a55e-a61c0e5e0798) |

Have confirmed that OBS 30.2.3 supports flexbox and renders this as expected.

The ideal here is probably to change this to being an actual table (since this _is_ tabular data), though that needs deeper reworking of the CSS.

Builds on https://github.com/srobo/livestream-overlay/pull/25